### PR TITLE
Style guide changes.  Change version of PE supported to work on PE 3.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,26 +1,28 @@
-# Class atomic
+# == Class: atomic
 #
 # Actions:
 #   Configure the proper repositories and import GPG keys
 #
 # Reqiures:
-#   You should probably be on an Enterprise Linux variant. (Centos, RHEL, Scientific, Oracle, Ascendos, et al)
+#   You should probably be on an Enterprise Linux variant. (Centos, RHEL,
+#   Scientific, Oracle, Ascendos, et al)
 #
 # Sample Usage:
 #  include atomic
 #
 class atomic (
-              $proxy = $atomic::params::proxy,
-              $includepkgs = $atomic::params::includepkgs,
-              $exclude = $atomic::params::exclude
-             ) inherits atomic::params {
+  $proxy       = $atomic::params::proxy,
+  $includepkgs = $atomic::params::includepkgs,
+  $exclude     = $atomic::params::exclude
+) inherits atomic::params {
 
   $gpgkeys = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY.art.txt
   file:///etc/pki/rpm-gpg/RPM-GPG-KEY.atomicorp.txt"
 
   if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
 
-    # This will be 5 or 6 on RedHat, 6 or wheezy on Debian, 12 or quantal on Ubuntu, etc.
+    # This will be 5 or 6 on RedHat, 6 or wheezy on Debian, 12 or quantal
+    # on Ubuntu, etc.
     $osr_array = split($::operatingsystemrelease,'[\/\.]')
     $distrelease = $osr_array[0]
 
@@ -64,32 +66,32 @@ class atomic (
       descr          => "CentOS / Red Hat Enterprise Linux ${distrelease} - atomicrocketturtle.com"
     }
 
-    file { "/etc/pki/rpm-gpg/RPM-GPG-KEY.art.txt":
+    file { '/etc/pki/rpm-gpg/RPM-GPG-KEY.art.txt':
       ensure => present,
       owner  => 'root',
       group  => 'root',
       mode   => '0644',
-      source => "puppet:///modules/atomic/RPM-GPG-KEY.art.txt",
+      source => 'puppet:///modules/atomic/RPM-GPG-KEY.art.txt',
     }
 
-    file { "/etc/pki/rpm-gpg/RPM-GPG-KEY.atomicorp.txt":
+    file { '/etc/pki/rpm-gpg/RPM-GPG-KEY.atomicorp.txt':
       ensure => present,
       owner  => 'root',
       group  => 'root',
       mode   => '0644',
-      source => "puppet:///modules/atomic/RPM-GPG-KEY.atomicorp.txt",
+      source => 'puppet:///modules/atomic/RPM-GPG-KEY.atomicorp.txt',
     }
 
-    atomic::rpm_gpg_key{ "art":
-      path => "/etc/pki/rpm-gpg/RPM-GPG-KEY.art.txt"
+    atomic::rpm_gpg_key{ 'art':
+      path => '/etc/pki/rpm-gpg/RPM-GPG-KEY.art.txt'
     }
 
-    atomic::rpm_gpg_key{ "atomicorp":
-      path => "/etc/pki/rpm-gpg/RPM-GPG-KEY.atomicorp.txt"
+    atomic::rpm_gpg_key{ 'atomicorp':
+      path => '/etc/pki/rpm-gpg/RPM-GPG-KEY.atomicorp.txt'
     }
 
   } else {
-      notice ("Your operating system ${::operatingsystem} will not have the atomic repository applied")
+    notice ("Your operating system ${::operatingsystem} will not have the atomic repository applied")
   }
 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,7 @@
+# == Class: atomic::params
+#
 # Optional parameters in setting up Atomic Repo
+#
 class atomic::params {
   # Setting to 'absent' will fall back to the yum.conf
   # Settings here will be the default for all repos.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "andyshinn-atomic",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "source": "http://github.com/andyshinn/puppet-atomic",
   "author": "andyshinn",
   "license": "Apache License, Version 2.0",
@@ -46,7 +46,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.0"
+      "version_requirement": "3.x"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
Module version bump to 0.1.4.  This will allow support for Puppet Enterprise 3.x.  Tested with Vagrant against PE 3.3.2.
